### PR TITLE
Prevent the game from going to the course select after rolling a random song

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -15,6 +15,7 @@ namespace TaikoMods
         public ConfigEntry<bool> ConfigSkipSplashScreen;
         public ConfigEntry<bool> ConfigDisableScreenChangeOnFocus;
         public ConfigEntry<bool> ConfigFixSignInScreen;
+        public ConfigEntry<bool> ConfigRandomSongSelectSkip;
         public ConfigEntry<bool> ConfigEnableCustomSongs;
         public ConfigEntry<string> ConfigSongDirectory;
         public ConfigEntry<string> ConfigSaveDirectory;
@@ -54,6 +55,11 @@ namespace TaikoMods
                 false,
                 "When focusing this wont do anything jank, I thnk");
             
+            this.ConfigRandomSongSelectSkip = Config.Bind("General",
+                "RandomSongSelectSkip",
+                true,
+                "When true, the game will not proceed to the song screen when selecting a random song, instead letting you re-roll");
+            
             ConfigEnableCustomSongs = Config.Bind("CustomSongs",
                 "EnableCustomSongs",
                 true,
@@ -83,6 +89,9 @@ namespace TaikoMods
             
             if (ConfigDisableScreenChangeOnFocus.Value)
                 _harmony.PatchAll(typeof(DisableScreenChangeOnFocus));
+            
+            if (ConfigRandomSongSelectSkip.Value)
+                _harmony.PatchAll(typeof(RandomSongSelectPatch));
             
             if (ConfigEnableCustomSongs.Value)
             {

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Currently has the features:
 - Skips splash screen
 - Disable fullscreen on application focus
 - Allows custom tracks to be loaded into the game
+- Keeps the game from opening the course menu when selecting a random song, so you can reroll instantly
 
 ----
 ## Installation

--- a/RandomSongSelectPatch.cs
+++ b/RandomSongSelectPatch.cs
@@ -1,0 +1,30 @@
+﻿using HarmonyLib;
+
+namespace TaikoMods;
+
+/// <summary>
+/// This patch prevents the game from advancing to the course select after rolling a random song
+/// </summary>
+[HarmonyPatch(typeof(SongSelectManager))]
+[HarmonyPatch("UpdateRandomSelect")]
+public class RandomSongSelectPatch
+{
+    // ReSharper disable once InconsistentNaming
+    private static bool Prefix(SongSelectManager __instance)
+    {
+        var stateTraverse = Traverse.Create(__instance).Field("currentRandomSelectState"); // SongSelectManager.RandomSelectState
+        var state = (int) stateTraverse.GetValue();
+
+        if (state == 2) // DecideSong
+        {
+            stateTraverse.SetValue(0); // Prepare
+            Traverse.Create(__instance).Method("ChangeState", SongSelectManager.State.SongSelect)
+                .GetValue(SongSelectManager.State.SongSelect); // Switch back to SongSelect mode
+            Traverse.Create(__instance).Field("isSongLoadRequested").SetValue(true); // Needed to have the game load the song preview
+
+            return false; // Don't call original method
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
This PR adds a patch that, if enabled, prevents the game from advancing to the course select screen when rolling a random song, enabling the player to reroll immediately.